### PR TITLE
[feat] add swagger documentation

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,10 +23,13 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^11.2.6",
     "@prisma/client": "^6.17.0",
     "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,9 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('Documentation with Swagger')
+    .setDescription('API description')
+    .setVersion('1.0')
+    .addTag('users')
+    .build();
+  const document = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(4200);
 }
-
 bootstrap();


### PR DESCRIPTION
##Descriptiom

The Swagger was integrated into the project to provide API documentation. The documentation can be accessed at:

http://localhost:4200/api

This interface allows users to explore the available endpoints, view the expected parameters, and test requests directly from the browser.

##Changes

[feat]: Add Swagger setup for API documentation.

##Preview

<img width="899" height="878" alt="image" src="https://github.com/user-attachments/assets/327b9945-67ab-47ee-b837-94ba65348dee" />
